### PR TITLE
无限滚动修改方案

### DIFF
--- a/ImagePlayerView/ImagePlayerView.m
+++ b/ImagePlayerView/ImagePlayerView.m
@@ -264,7 +264,7 @@
     NSInteger currentPage = self.pageControl.currentPage;
     NSInteger nextPage = currentPage + 1;
     if (self.endlessScroll
-        && nextPage == self.count) {
+        && nextPage == self.count + 1) {
         nextPage = 0;
     }
     


### PR DESCRIPTION
定时器无限滚动到count时，collectionView会回滚到top，用户体验差，修改为滚到count+1 再替换为0，提升用户体验